### PR TITLE
#57 business admin can close bid

### DIFF
--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -17,4 +17,11 @@ class BidsController < ApplicationController
     flash[:success] = "Placed a bid for #{format_price(item.max_bid)} on #{item.title}"
     redirect_to shop_item_path(shop: item.shop.slug, id: item.id)
   end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.update(retired: true)
+    flash[:success] = "Item #{item.title} has been closed for bidding"
+    redirect_to shop_item_path(shop: item.shop.slug, id: item.id)
+  end
 end

--- a/app/views/shop/items/show.html.erb
+++ b/app/views/shop/items/show.html.erb
@@ -6,7 +6,8 @@
         <h3><%= format_price(@item.price) %></h3>
         <p>
           <% if @item.retired? %>
-            <%= "Sorry, this item is no longer available" %>
+            <h3>This item is closed</h3>
+            <h3>Item won for <%= format_price(@item.max_bid) %></h3>
           <% else %>
             <% if @item.bid? %>
               <%= button_to "Bid", bids_path(item: @item.id) %>
@@ -19,6 +20,9 @@
         <% if current_user && current_user.business_admin? %>
           <p><%= link_to "Edit", edit_admin_item_path(@item.id), class: "btn btn-default" %>
           <p><%= link_to "Delete", admin_item_path(@item.id), method: :delete, class: "btn btn-default" %>
+          <% if @item.bid? && !@item.retired? %>
+            <p><%= link_to "Close bidding", bid_path(@item), method: :delete, class: "btn btn-default" %></p>
+          <% end %>
         <% end %>
       </div>
       <div class="col-md-12 text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,6 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show]
   end
 
-  resources :bids, only: [:create]
+  resources :bids, only: [:create, :destroy]
   get "/dashboard/bids", to: "bids#index", as: :user_bids
 end

--- a/spec/features/business_admin_can_close_bid_spec.rb
+++ b/spec/features/business_admin_can_close_bid_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+feature "Business admin can close bid" do
+  scenario "a user wins the bid and the item is retired" do
+    create_business_admin_and_shop
+    admin = User.first
+    shop = Shop.first
+    item = FactoryGirl.create(:item, bid: true)
+    shop.items << item
+    logout(admin)
+
+    user = FactoryGirl.create(:user)
+    login(user)
+
+    visit shops_path
+    click_link shop.name
+    click_link item.title
+    click_link "Bid"
+
+    logout(user)
+    login(admin)
+
+    visit shop_item_path(shop: shop.slug, id: item.id)
+
+    expect(page).to have_link("Close bidding")
+
+    click_link "Close bidding"
+
+    expect(current_path).to eq(shop_item_path(shop: shop.slug, id: item.id))
+    expect(page).to have_content("Item #{item.title} has been closed for bidding")
+    expect(page).to_not have_link("Bid")
+    expect(page).to have_content("This item is closed")
+    expect(page).to have_content("Item won for #{item.price}")
+
+    # ...continue with the mechanics for closing out a bid
+  end
+end

--- a/spec/features/business_admin_can_close_bid_spec.rb
+++ b/spec/features/business_admin_can_close_bid_spec.rb
@@ -15,7 +15,7 @@ feature "Business admin can close bid" do
     visit shops_path
     click_link shop.name
     click_link item.title
-    click_link "Bid"
+    click_button "Bid"
 
     logout(user)
     login(admin)
@@ -30,8 +30,7 @@ feature "Business admin can close bid" do
     expect(page).to have_content("Item #{item.title} has been closed for bidding")
     expect(page).to_not have_link("Bid")
     expect(page).to have_content("This item is closed")
-    expect(page).to have_content("Item won for #{item.price}")
-
-    # ...continue with the mechanics for closing out a bid
+    expect(page).to have_content("Item won for $1.00")
+    expect(page).to_not have_link("Close bidding")
   end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -9,6 +9,11 @@ module Helpers
     end
   end
 
+  def logout(user)
+    visit "/"
+    click_on "Sign Out"
+  end
+
   def create_business_admin_and_shop
     user = User.create(username: "Brock", password: "password")
     login(user)


### PR DESCRIPTION
This allows an admin to close a bid. This sets the item to retired,
does not allow any further bidding and display information about the
winning bid.

@julyytran @Unsafepond 

Closes #57
